### PR TITLE
fix: 修复设备文件传输跨平台兼容性

### DIFF
--- a/.trellis/spec/backend/quality-guidelines.md
+++ b/.trellis/spec/backend/quality-guidelines.md
@@ -46,6 +46,63 @@ Rust commands and pure helpers use colocated `#[cfg(test)]` unit tests. Verifica
 - 跨平台: Windows/macOS/Linux 路径和进程处理是否兼容
 - 新增依赖是否必要, 是否指定了版本
 
+## Scenario: Hidden ADB Child Processes on Windows
+
+### 1. Scope / Trigger
+
+- Trigger: adding or changing any synchronous or asynchronous host process used for ADB discovery, polling, streaming, or device operations.
+- Applies to release builds that use the Windows GUI subsystem and therefore have no parent console for child console applications to inherit.
+
+### 2. Signatures
+
+- `new_command(program: &str) -> std::process::Command`
+- `prepare_command(app: &AppHandle, adb_path: &str) -> std::process::Command`
+- `prepare_async_command(app: &AppHandle, adb_path: &str) -> tokio::process::Command`
+- `which_adb() -> Result<String, String>` must create `where` / `which` through the shared synchronous constructor.
+
+### 3. Contracts
+
+- On Windows, every host console process created by the ADB infrastructure uses `CREATE_NO_WINDOW` (`0x08000000`).
+- Both `std::process::Command` and `tokio::process::Command` paths have the same hidden-window behavior.
+- On macOS and Linux, command creation remains unchanged.
+- Process arguments, exit status, stdout, stderr, and existing `Result<T, String>` behavior are unchanged.
+
+### 4. Validation & Error Matrix
+
+- Windows GUI release + missing `CREATE_NO_WINDOW` -> each short ADB poll can flash a console window.
+- Windows async ADB stream + missing `CREATE_NO_WINDOW` -> a console window can remain visible for the stream lifetime.
+- Non-Windows build -> do not import `std::os::windows::process::CommandExt` or apply Windows creation flags.
+- Hidden child exits with an error -> preserve stderr and status handling; hiding the window must not hide the error from the caller.
+
+### 5. Good/Base/Bad Cases
+
+- Good: the three-second `adb devices -l` poll runs repeatedly in a Windows release build without creating a visible console window.
+- Base: `where adb` and `adb version` run once during startup through the same hidden synchronous constructor.
+- Good: logcat uses the hidden async constructor and still exposes piped stdout.
+- Bad: calling `Command::new("adb")` directly from a command module bypasses the Windows flag and can reintroduce flashing windows.
+
+### 6. Tests Required
+
+- Windows compile check: `cargo check --manifest-path src-tauri/Cargo.toml` must compile both creation-flag call sites.
+- Regression suite: `cargo test --manifest-path src-tauri/Cargo.toml` and Clippy must pass.
+- Release smoke: build with `pnpm tauri build --no-bundle`, connect an ADB device or emulator, run for at least two device-poll intervals, and assert that device/activity updates continue with no Console, Command Prompt, or Terminal window appearing.
+
+### 7. Wrong vs Correct
+
+#### Wrong
+
+```rust
+let command = Command::new(adb_path);
+```
+
+#### Correct
+
+```rust
+let mut command = Command::new(program);
+#[cfg(windows)]
+command.creation_flags(CREATE_NO_WINDOW);
+```
+
 ## Scenario: ADB Port Forward Commands
 
 ### 1. Scope / Trigger

--- a/.trellis/spec/frontend/quality-guidelines.md
+++ b/.trellis/spec/frontend/quality-guidelines.md
@@ -51,3 +51,57 @@
 - 是否有未处理的 Promise (需 catch 或 void)
 - 响应式布局: 是否在窄屏下可用
 - 暗色/亮色模式: 是否使用语义 token (不硬编码颜色)
+
+## Scenario: Device Download Default Filenames
+
+### 1. Scope / Trigger
+
+- Trigger: adding or changing a system save dialog whose suggested filename comes from an Android device.
+- Applies to device-file downloads through the Tauri bridge on Windows, macOS, and Linux.
+
+### 2. Signatures
+
+- `deviceDownloadDefaultName(fileName: string, pathSeparator: string) -> string`
+- `pickDeviceDownloadPath(fileName: string) -> Promise<string | null>`
+
+### 3. Contracts
+
+- `fileName` is already the basename returned by the device-file backend. Do not parse it again with a host-native `basename` API because Android permits characters that have path semantics on Windows.
+- Use Tauri `sep()` only to select the host filename rules, then pass the result to the pure helper.
+- On Windows, replace `< > : " / \ | ? *` and control characters with `_`, replace trailing dots/spaces with `_`, and prefix reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, `LPT1-9`, including extensions) with `_`.
+- On macOS and Linux, preserve the original UTF-8 device filename, including Chinese characters, spaces, single quotes, colons, and backslashes.
+- Empty, `.` and `..` names fall back to `device-file` on every platform.
+
+### 4. Validation & Error Matrix
+
+- Windows-invalid character -> replace that character with `_` before calling `join()` or opening the save dialog.
+- Windows reserved basename with or without an extension -> prefix the complete name with `_`.
+- Empty, `.` or `..` -> use `device-file`; never pass a non-file name to the dialog.
+- User cancels the save dialog -> return `null` without displaying an error.
+
+### 5. Good/Base/Bad Cases
+
+- Good: Windows maps `a\\b.txt` to `a_b.txt`, `CON.txt` to `_CON.txt`, and `report. ` to `report__`.
+- Base: POSIX hosts preserve `设备 文件's.txt` byte-for-byte.
+- Bad: `basename(fileName)` on Windows treats an Android backslash as a host separator and silently changes the suggested filename.
+
+### 6. Tests Required
+
+- Unit-test Windows backslashes, colons, control characters, reserved names with extensions, and trailing dots/spaces.
+- Unit-test the empty/`.`/`..` fallback.
+- Unit-test POSIX preservation with Chinese characters, spaces, and single quotes.
+- Run `pnpm test` and `pnpm build` after changing the helper or dialog bridge.
+
+### 7. Wrong vs Correct
+
+#### Wrong
+
+```typescript
+const defaultName = await basename(fileName);
+```
+
+#### Correct
+
+```typescript
+const defaultName = deviceDownloadDefaultName(fileName, sep());
+```

--- a/src-tauri/src/adb.rs
+++ b/src-tauri/src/adb.rs
@@ -3,6 +3,12 @@ use std::process::Command;
 use std::sync::Mutex;
 use tauri::{AppHandle, Manager};
 
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 pub struct AppState {
     pub adb_path: Mutex<String>,
 }
@@ -65,7 +71,11 @@ fn find_adb(app: &AppHandle) -> Result<String, String> {
     } else {
         "linux"
     };
-    let adb_name = if cfg!(target_os = "windows") { "adb.exe" } else { "adb" };
+    let adb_name = if cfg!(target_os = "windows") {
+        "adb.exe"
+    } else {
+        "adb"
+    };
     let embedded = resource_dir.join(platform_dir).join(adb_name);
     if embedded.exists() {
         if cfg!(target_family = "unix") {
@@ -85,7 +95,7 @@ fn find_adb(app: &AppHandle) -> Result<String, String> {
 }
 
 pub fn prepare_command(app: &AppHandle, adb_path: &str) -> Command {
-    let mut command = Command::new(adb_path);
+    let mut command = new_command(adb_path);
     if let Some(lib_dir) = embedded_linux_lib_dir(app, adb_path) {
         command.env("LD_LIBRARY_PATH", lib_dir);
     }
@@ -94,9 +104,18 @@ pub fn prepare_command(app: &AppHandle, adb_path: &str) -> Command {
 
 pub fn prepare_async_command(app: &AppHandle, adb_path: &str) -> tokio::process::Command {
     let mut command = tokio::process::Command::new(adb_path);
+    #[cfg(windows)]
+    command.creation_flags(CREATE_NO_WINDOW);
     if let Some(lib_dir) = embedded_linux_lib_dir(app, adb_path) {
         command.env("LD_LIBRARY_PATH", lib_dir);
     }
+    command
+}
+
+fn new_command(program: &str) -> Command {
+    let mut command = Command::new(program);
+    #[cfg(windows)]
+    command.creation_flags(CREATE_NO_WINDOW);
     command
 }
 
@@ -123,7 +142,7 @@ fn is_path_within(path: &str, root: &PathBuf) -> bool {
 
 #[cfg(unix)]
 fn which_adb() -> Result<String, String> {
-    let output = std::process::Command::new("which")
+    let output = new_command("which")
         .arg("adb")
         .output()
         .map_err(|e| format!("which failed: {e}"))?;
@@ -138,12 +157,17 @@ fn which_adb() -> Result<String, String> {
 
 #[cfg(windows)]
 fn which_adb() -> Result<String, String> {
-    let output = std::process::Command::new("where")
+    let output = new_command("where")
         .arg("adb")
         .output()
         .map_err(|e| format!("where failed: {e}"))?;
     if output.status.success() {
-        let p = String::from_utf8_lossy(&output.stdout).lines().next().unwrap_or("").trim().to_string();
+        let p = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
         if !p.is_empty() {
             return Ok(p);
         }
@@ -167,11 +191,19 @@ pub fn get_adb_version(app: &AppHandle, adb_path: &str) -> String {
 }
 
 pub fn adb_source(adb_path: &str, app: &AppHandle) -> String {
-    let resource_dir = app.path().resource_dir().map(|d| d.to_string_lossy().to_string()).unwrap_or_default();
+    let resource_dir = app
+        .path()
+        .resource_dir()
+        .map(|d| d.to_string_lossy().to_string())
+        .unwrap_or_default();
     if adb_path.starts_with(&resource_dir) {
         "embedded".to_string()
-    } else if std::env::var("ANDROID_HOME").map(|h| adb_path.contains(&h)).unwrap_or(false)
-        || std::env::var("ANDROID_SDK_ROOT").map(|h| adb_path.contains(&h)).unwrap_or(false)
+    } else if std::env::var("ANDROID_HOME")
+        .map(|h| adb_path.contains(&h))
+        .unwrap_or(false)
+        || std::env::var("ANDROID_SDK_ROOT")
+            .map(|h| adb_path.contains(&h))
+            .unwrap_or(false)
     {
         "sdk".to_string()
     } else {

--- a/src-tauri/src/commands/device_files.rs
+++ b/src-tauri/src/commands/device_files.rs
@@ -293,7 +293,9 @@ fn parse_directory_records(output: &[u8], directory: &str) -> Result<Vec<DeviceF
     }
 
     let mut entries = Vec::with_capacity(fields.len() / 4);
-    for record in fields.chunks_exact(4) {
+    let (records, remainder) = fields.as_chunks::<4>();
+    debug_assert!(remainder.is_empty());
+    for record in records {
         let kind = match utf8_field(record[0], "类型")? {
             "directory" => DeviceFileKind::Directory,
             "file" => DeviceFileKind::File,

--- a/src/lib/deviceFiles.test.ts
+++ b/src/lib/deviceFiles.test.ts
@@ -3,6 +3,7 @@ import type { DeviceDirectoryListing, DeviceFileEntry } from "@/lib/tauri";
 import {
   buildDeviceBreadcrumbs,
   createDeviceFileManagerState,
+  deviceDownloadDefaultName,
   deviceFileManagerReducer,
   deviceTransferSummary,
   deviceFileTypeLabel,
@@ -46,6 +47,22 @@ describe("device file helpers", () => {
     expect(deviceFileTypeLabel(imageEntry)).toBe("PNG");
     expect(deviceFileTypeLabel({ ...imageEntry, kind: "directory" })).toBe("文件夹");
     expect(localFileName("C:\\Users\\qi\\photo.png")).toBe("photo.png");
+  });
+
+  it("creates Windows-safe default names for device downloads", () => {
+    expect(deviceDownloadDefaultName("a\\b.txt", "\\")).toBe("a_b.txt");
+    expect(deviceDownloadDefaultName("a:b.txt", "\\")).toBe("a_b.txt");
+    expect(deviceDownloadDefaultName("CON.txt", "\\")).toBe("_CON.txt");
+    expect(deviceDownloadDefaultName("report. ", "\\")).toBe("report__");
+    expect(deviceDownloadDefaultName("line\u0000break.txt", "\\")).toBe(
+      "line_break.txt",
+    );
+    expect(deviceDownloadDefaultName("..", "\\")).toBe("device-file");
+  });
+
+  it("preserves valid device names on POSIX hosts", () => {
+    const fileName = "设备 文件's.txt";
+    expect(deviceDownloadDefaultName(fileName, "/")).toBe(fileName);
   });
 
   it("invalidates operation snapshots across device ABA changes and unmounts", () => {

--- a/src/lib/deviceFiles.ts
+++ b/src/lib/deviceFiles.ts
@@ -350,6 +350,32 @@ export function localFileName(path: string): string {
   return path.split(/[\\/]/).pop() || path;
 }
 
+export function deviceDownloadDefaultName(
+  fileName: string,
+  pathSeparator: string,
+): string {
+  if (!fileName || fileName === "." || fileName === "..") {
+    return "device-file";
+  }
+  if (pathSeparator !== "\\") {
+    return fileName;
+  }
+
+  let safeName = fileName.replace(
+    /[\u0000-\u001f\u007f-\u009f<>:"\/\\|?*]/g,
+    "_",
+  );
+  safeName = safeName.replace(/[. ]+$/g, (suffix) => "_".repeat(suffix.length));
+
+  if (!safeName || safeName === "." || safeName === "..") {
+    return "device-file";
+  }
+  if (/^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i.test(safeName)) {
+    return `_${safeName}`;
+  }
+  return safeName;
+}
+
 export function isDeviceTransferBusy(transfer: DeviceTransferBatch | null): boolean {
   return transfer?.status === "running";
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,10 +1,11 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { basename, downloadDir, join } from "@tauri-apps/api/path";
+import { downloadDir, join, sep } from "@tauri-apps/api/path";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
 import { getCurrentWebview, type DragDropEvent } from "@tauri-apps/api/webview";
+import { deviceDownloadDefaultName } from "@/lib/deviceFiles";
 
 export interface DeviceInfo {
   serial: string;
@@ -226,10 +227,7 @@ export async function pickDeviceUploadFiles(): Promise<string[]> {
 }
 
 export async function pickDeviceDownloadPath(fileName: string): Promise<string | null> {
-  const defaultName = await basename(fileName);
-  if (!defaultName || defaultName === "." || defaultName === "..") {
-    throw new Error("无法生成本地保存文件名");
-  }
+  const defaultName = deviceDownloadDefaultName(fileName, sep());
   const defaultPath = await join(await downloadDir(), defaultName);
   return save({
     title: "保存设备文件",


### PR DESCRIPTION
## Summary

- sanitize Android download filenames for Windows while preserving POSIX UTF-8 names
- hide synchronous and asynchronous ADB child processes in Windows GUI builds
- adopt the Rust 1.98 fixed-array slice API for directory record parsing
- document both cross-platform compatibility contracts

## Verification

- `pnpm test` (26 passed)
- `pnpm build`
- `cargo test` (28 passed)
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- targeted `rustfmt --check` for changed Rust files
- `pnpm tauri build --no-bundle`
- `git diff --check`

## Note

Full-repository `cargo fmt --check` still reports pre-existing formatting differences in `device_info.rs`, `keys.rs`, and `screenshot.rs`; those unrelated files are intentionally excluded from this PR.