### PR TITLE
fix: avoid Windows clippy unused app warning

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -223,7 +223,7 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while running tauri application");
 
-    app.run(|app, event| match event {
+    app.run(|_app, event| match event {
         tauri::RunEvent::Exit => {
             if let Err(error) =
                 tauri::async_runtime::block_on(commands::logcat::shutdown_logcat_sessions())
@@ -235,7 +235,7 @@ pub fn run() {
         tauri::RunEvent::Reopen {
             has_visible_windows: false,
             ..
-        } => show_primary_window(app),
+        } => show_primary_window(_app),
         _ => {}
     });
 }


### PR DESCRIPTION
## Summary

- rename the Tauri run-loop app handle binding to support platform-conditional use
- preserve the macOS reopen behavior while avoiding an unused-variable warning on Windows

## Verification

- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml` (57 passed)
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `pnpm test` (215 passed)
- `pnpm build`
- `git diff --check`