### PR TITLE
fix: make Windows reinstall safe and unify the title bar

### DIFF
--- a/.trellis/spec/backend/quality-guidelines.md
+++ b/.trellis/spec/backend/quality-guidelines.md
@@ -103,6 +103,77 @@ let mut command = Command::new(program);
 command.creation_flags(CREATE_NO_WINDOW);
 ```
 
+## Scenario: Windows Reinstall with a Bundled ADB Server
+
+### 1. Scope / Trigger
+
+- Trigger: changing the embedded Platform Tools bundle, Windows NSIS installer/updater hooks, ADB path resolution, or application shutdown.
+- The installed `windows/adb.exe` can fork a server that outlives `adb-gui.exe`. That server keeps `AdbWinApi.dll` and `AdbWinUsbApi.dll` loaded, so a reinstall can fail with `Error opening file for writing` even after the UI has closed.
+
+### 2. Signatures
+
+- Runtime cleanup helper: `shutdown_embedded_adb_server(app: &AppHandle) -> Result<(), String>`.
+- NSIS lifecycle hooks: `!macro NSIS_HOOK_PREINSTALL` and `!macro NSIS_HOOK_PREUNINSTALL`, registered through `bundle.windows.nsis.installerHooks`.
+- Graceful server command: `<installed resource dir>/windows/adb.exe kill-server`.
+
+### 3. Contracts
+
+- Treat the ADB server as a separately owned process, not as a child whose lifetime automatically follows `adb-gui.exe`.
+- Runtime shutdown must run after direct ADB children such as Logcat have stopped and before the application process exits.
+- Only stop a server whose resolved executable path is inside this application's installed resource directory. A server from Android Studio, an SDK, or `PATH` is external state and must not be terminated merely because its process name is `adb.exe`.
+- The NSIS preinstall hook is authoritative for upgrades and reinstalls because an already released version may not contain runtime cleanup. It must inspect running process executable paths, stop an exact-path bundled server, wait for that process to exit, and only then allow file replacement.
+- Apply the same ownership-aware cleanup before uninstalling so the resource directory can be removed completely.
+- Do not use `adb server-status` only to test whether a server exists: with no server running, that command starts one and creates the lock being checked. On Windows, inspect the process table without launching ADB; `server-status` is diagnostic only after an existing server has been established.
+
+### 4. Validation & Error Matrix
+
+- No `adb.exe` from the install directory is running -> continue install/uninstall without launching ADB.
+- Exact install-directory server is running -> request `kill-server`, wait for exit, then replace/remove both ADB DLLs.
+- An `adb.exe` from another absolute path is running -> leave it untouched and continue; it does not own the bundled DLLs.
+- Bundled server does not exit before the timeout -> abort before copying files and show an actionable close/retry error; never recommend Ignore because that produces a mixed-version Platform Tools directory.
+- Runtime exit cleanup fails -> log the error and allow app exit; the installer hook remains the recovery boundary.
+- Old `windows/adb.exe` is missing -> skip the graceful command and continue unless an exact-path process still owns the resource files.
+
+### 5. Good/Base/Bad Cases
+
+- Good: launch the installed app, let `adb devices -l` start the bundled server, close the app, and reinstall without a write error for either ADB DLL.
+- Good: reinstall a legacy build while its bundled server is still running; the new installer's preinstall hook releases the old DLLs before extraction.
+- Base: Android Studio has an SDK `adb.exe` server running from another directory; reinstall succeeds without stopping that external server.
+- Bad: cleaning only `adb-gui.exe` or direct Logcat children leaves the forked server alive and the DLLs locked.
+- Bad: unconditional `taskkill /IM adb.exe /F` disrupts unrelated development tools and violates executable-path ownership.
+- Bad: relying only on the new application's exit handler cannot repair reinstallation from versions released before that handler existed.
+
+### 6. Tests Required
+
+- Rust unit tests must cover embedded-path matching, case-insensitive Windows path comparison, missing cached ADB state, and external SDK paths.
+- Installer smoke: record the PID and `ExecutablePath` of the bundled server, run a same-version reinstall, and assert that the PID exits and the installed `AdbWinApi.dll` hash matches the package.
+- Upgrade smoke: repeat from the last public installer to the candidate installer so the NSIS hook, not new runtime code, proves backward recovery.
+- External-server smoke: start ADB from a different SDK directory, reinstall, and assert that exact PID is still running.
+- Uninstall smoke: start the bundled server, uninstall, and assert that no install-directory process or ADB DLL remains.
+- Diagnostic command on Windows:
+
+```powershell
+Get-CimInstance Win32_Process -Filter "Name = 'adb.exe'" |
+  Select-Object ProcessId, ExecutablePath, CommandLine
+```
+
+### 7. Wrong vs Correct
+
+#### Wrong
+
+```nsh
+nsExec::ExecToLog 'taskkill /IM adb.exe /F'
+```
+
+#### Correct
+
+```text
+1. Enumerate running adb.exe processes without starting a new ADB server.
+2. Match the normalized executable path against $INSTDIR\windows\adb.exe.
+3. Ask that installed executable to run kill-server and wait for the matched PID to exit.
+4. Abort before extraction if the exact-path process still owns the DLLs.
+```
+
 ## Scenario: Batch Android Application Metadata Helper
 
 ### 1. Scope / Trigger

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-updater",
  "tokio",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,3 +34,11 @@ base64 = "0.22"
 dirs = "6"
 log = "0.4"
 chrono = "0.4"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_Globalization",
+  "Win32_System_Diagnostics_ToolHelp",
+  "Win32_System_Threading",
+] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,10 @@
     "shell:default",
     "fs:default",
     "process:default",
-    "updater:default"
+    "updater:default",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-start-dragging"
   ]
 }

--- a/src-tauri/src/adb.rs
+++ b/src-tauri/src/adb.rs
@@ -1,28 +1,75 @@
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::Mutex;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Mutex,
+};
 use tauri::{AppHandle, Manager};
 
 #[cfg(windows)]
+use std::ffi::OsString;
+#[cfg(windows)]
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+#[cfg(windows)]
 use std::os::windows::process::CommandExt;
+#[cfg(windows)]
+use std::path::Path;
+#[cfg(windows)]
+use std::time::{Duration, Instant};
+#[cfg(windows)]
+use windows_sys::Win32::{
+    Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
+    Globalization::{CompareStringOrdinal, CSTR_EQUAL},
+    System::{
+        Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+            TH32CS_SNAPPROCESS,
+        },
+        Threading::{OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION},
+    },
+};
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+#[cfg(windows)]
+const ADB_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
+#[cfg(windows)]
+const ADB_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(50);
+#[cfg(windows)]
+const ADB_ABSENCE_CONFIRMATION: Duration = Duration::from_millis(150);
+#[cfg(windows)]
+const ADB_KILL_RETRY_INTERVAL: Duration = Duration::from_millis(250);
+
 pub struct AppState {
     pub adb_path: Mutex<String>,
+    shutting_down: AtomicBool,
 }
 
 impl AppState {
     pub fn new() -> Self {
         Self {
             adb_path: Mutex::new(String::new()),
+            shutting_down: AtomicBool::new(false),
         }
     }
 }
 
+pub fn begin_shutdown(app: &AppHandle) {
+    app.state::<AppState>()
+        .shutting_down
+        .store(true, Ordering::SeqCst);
+}
+
+pub fn is_shutting_down(app: &AppHandle) -> bool {
+    app.state::<AppState>().shutting_down.load(Ordering::SeqCst)
+}
+
 pub fn resolve_adb_path(app: &AppHandle) -> Result<String, String> {
     let state = app.state::<AppState>();
+    if state.shutting_down.load(Ordering::SeqCst) {
+        return Err("application is shutting down".to_string());
+    }
     {
         let cached = state.adb_path.lock().unwrap();
         if !cached.is_empty() {
@@ -212,5 +259,206 @@ pub fn adb_source(adb_path: &str, app: &AppHandle) -> String {
         "sdk".to_string()
     } else {
         "system".to_string()
+    }
+}
+
+#[cfg(not(windows))]
+pub fn shutdown_embedded_adb_server(_app: &AppHandle) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn shutdown_embedded_adb_server(app: &AppHandle) -> Result<(), String> {
+    let adb_path = {
+        let state = app.state::<AppState>();
+        let cached = state.adb_path.lock().unwrap();
+        if cached.is_empty() {
+            return Ok(());
+        }
+        PathBuf::from(cached.as_str())
+    };
+    let resource_dir = app
+        .path()
+        .resource_dir()
+        .map_err(|error| error.to_string())?;
+    let expected_path = resource_dir.join("windows").join("adb.exe");
+    if !windows_paths_equal(&adb_path, &expected_path) {
+        return Ok(());
+    }
+
+    stop_adb_server_at_path(app, &adb_path)
+}
+
+#[cfg(windows)]
+fn stop_adb_server_at_path(app: &AppHandle, adb_path: &Path) -> Result<(), String> {
+    let started_at = Instant::now();
+    let mut empty_since = None;
+    let mut next_kill_attempt = started_at;
+    let mut last_error = None;
+
+    loop {
+        let process_ids = windows_process_ids_at_path(adb_path)?;
+        let now = Instant::now();
+        if process_ids.is_empty() {
+            let absence_started = empty_since.get_or_insert(now);
+            if now.duration_since(*absence_started) >= ADB_ABSENCE_CONFIRMATION {
+                return Ok(());
+            }
+        } else {
+            empty_since = None;
+            if now >= next_kill_attempt {
+                match prepare_command(app, &adb_path.to_string_lossy())
+                    .arg("kill-server")
+                    .output()
+                {
+                    Ok(output) if output.status.success() => last_error = None,
+                    Ok(output) => {
+                        let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                        last_error = Some(if detail.is_empty() {
+                            format!("adb kill-server exited with {}", output.status)
+                        } else {
+                            detail
+                        });
+                    }
+                    Err(error) => {
+                        last_error = Some(format!("failed to run adb kill-server: {error}"))
+                    }
+                }
+                next_kill_attempt = now + ADB_KILL_RETRY_INTERVAL;
+            }
+        }
+
+        if now.duration_since(started_at) >= ADB_SHUTDOWN_TIMEOUT {
+            let process_ids = windows_process_ids_at_path(adb_path)?;
+            if process_ids.is_empty() {
+                return Ok(());
+            }
+            let detail = last_error
+                .map(|error| format!(" Last error: {error}"))
+                .unwrap_or_default();
+            return Err(format!(
+                "bundled ADB server did not exit within 3 seconds (PIDs: {}).{detail}",
+                process_ids
+                    .iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+
+        std::thread::sleep(ADB_SHUTDOWN_POLL_INTERVAL);
+    }
+}
+
+#[cfg(windows)]
+fn windows_process_ids_at_path(expected_path: &Path) -> Result<Vec<u32>, String> {
+    // SAFETY: the returned snapshot handle is validated and owned until this function returns.
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(format!(
+            "failed to enumerate Windows processes: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    let snapshot = OwnedHandle(snapshot);
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+    let mut matches = Vec::new();
+
+    // SAFETY: entry has the required size and remains valid for the complete enumeration.
+    let mut has_entry = unsafe { Process32FirstW(snapshot.0, &mut entry) } != 0;
+    while has_entry {
+        if process_entry_name(&entry).eq_ignore_ascii_case("adb.exe") {
+            if let Some(path) = process_image_path(entry.th32ProcessID) {
+                if windows_paths_equal(&path, expected_path) {
+                    matches.push(entry.th32ProcessID);
+                }
+            }
+        }
+        // SAFETY: snapshot and entry remain valid until the loop completes.
+        has_entry = unsafe { Process32NextW(snapshot.0, &mut entry) } != 0;
+    }
+
+    Ok(matches)
+}
+
+#[cfg(windows)]
+fn process_entry_name(entry: &PROCESSENTRY32W) -> String {
+    let length = entry
+        .szExeFile
+        .iter()
+        .position(|character| *character == 0)
+        .unwrap_or(entry.szExeFile.len());
+    String::from_utf16_lossy(&entry.szExeFile[..length])
+}
+
+#[cfg(windows)]
+fn process_image_path(process_id: u32) -> Option<PathBuf> {
+    // SAFETY: the process handle is checked for null and closed by OwnedHandle.
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, process_id) };
+    if process.is_null() {
+        return None;
+    }
+    let process = OwnedHandle(process);
+    let mut buffer = vec![0_u16; 32_768];
+    let mut length = buffer.len() as u32;
+    // SAFETY: buffer is writable for length UTF-16 code units and the process handle is valid.
+    if unsafe { QueryFullProcessImageNameW(process.0, 0, buffer.as_mut_ptr(), &mut length) } == 0 {
+        return None;
+    }
+    buffer.truncate(length as usize);
+    Some(PathBuf::from(OsString::from_wide(&buffer)))
+}
+
+#[cfg(windows)]
+fn windows_paths_equal(left: &Path, right: &Path) -> bool {
+    let left: Vec<u16> = left.as_os_str().encode_wide().collect();
+    let right: Vec<u16> = right.as_os_str().encode_wide().collect();
+    // SAFETY: both pointers are valid for their explicit UTF-16 lengths.
+    unsafe {
+        CompareStringOrdinal(
+            left.as_ptr(),
+            left.len() as i32,
+            right.as_ptr(),
+            right.len() as i32,
+            1,
+        ) == CSTR_EQUAL
+    }
+}
+
+#[cfg(windows)]
+struct OwnedHandle(HANDLE);
+
+#[cfg(windows)]
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        // SAFETY: OwnedHandle is created only from a valid owned Windows handle.
+        unsafe {
+            CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::windows_paths_equal;
+    use std::path::Path;
+
+    #[test]
+    fn windows_path_matching_is_case_insensitive_and_exact() {
+        assert!(windows_paths_equal(
+            Path::new(r"C:\Users\Gin\AppData\Local\ADB GUI\windows\adb.exe"),
+            Path::new(r"c:\users\gin\appdata\local\adb gui\WINDOWS\ADB.EXE")
+        ));
+        assert!(!windows_paths_equal(
+            Path::new(r"C:\Android\platform-tools\adb.exe"),
+            Path::new(r"C:\Users\Gin\AppData\Local\ADB GUI\windows\adb.exe")
+        ));
+        assert!(!windows_paths_equal(
+            Path::new(r"C:\Users\Gin\AppData\Local\ADB GUI\windows\adb-old.exe"),
+            Path::new(r"C:\Users\Gin\AppData\Local\ADB GUI\windows\adb.exe")
+        ));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,7 +17,13 @@ fn start_device_poll(app: &AppHandle) {
     let app_handle = app.clone();
     tauri::async_runtime::spawn(async move {
         loop {
+            if adb::is_shutting_down(&app_handle) {
+                break;
+            }
             if let Ok(devices) = commands::device::list_devices(app_handle.clone()) {
+                if adb::is_shutting_down(&app_handle) {
+                    break;
+                }
                 let _ = app_handle.emit("devices-updated", &devices);
             }
             tokio::time::sleep(Duration::from_secs(3)).await;
@@ -226,10 +232,14 @@ pub fn run() {
 
     app.run(|_app, event| match event {
         tauri::RunEvent::Exit => {
+            adb::begin_shutdown(_app);
             if let Err(error) =
                 tauri::async_runtime::block_on(commands::logcat::shutdown_logcat_sessions())
             {
                 eprintln!("failed to stop Logcat sessions during application exit: {error}");
+            }
+            if let Err(error) = adb::shutdown_embedded_adb_server(_app) {
+                eprintln!("failed to stop bundled ADB server during application exit: {error}");
             }
         }
         #[cfg(target_os = "macos")]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,6 +36,11 @@
     "resources": {
       "resources/": ""
     },
+    "windows": {
+      "nsis": {
+        "installerHooks": "windows/installer-hooks.nsh"
+      }
+    },
     "createUpdaterArtifacts": true
   },
   "plugins": {

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "./gen/schemas/desktop-schema.json",
+  "app": {
+    "windows": [
+      {
+        "title": "ADB GUI",
+        "width": 1200,
+        "height": 800,
+        "minWidth": 900,
+        "minHeight": 600,
+        "decorations": false
+      }
+    ]
+  }
+}

--- a/src-tauri/windows/installer-hooks.nsh
+++ b/src-tauri/windows/installer-hooks.nsh
@@ -1,0 +1,34 @@
+!macro STOP_BUNDLED_ADB
+  ; Tauri places custom hooks before its app-running check. Run the same check
+  ; first so a legacy app cannot restart ADB after cleanup and before extraction.
+  !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+
+  stop_bundled_adb_retry:
+    ; Pass the path through the child environment so unusual install-directory
+    ; characters cannot alter the PowerShell command text.
+    System::Call 'Kernel32::SetEnvironmentVariableW(w "ADB_GUI_BUNDLED_ADB", w "$INSTDIR\windows\adb.exe") i .r2'
+    nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "& { $$target = [IO.Path]::GetFullPath($$env:ADB_GUI_BUNDLED_ADB); function GetOwnedAdb { @(Get-Process -Name adb -ErrorAction SilentlyContinue | Where-Object { try { [string]::Equals([IO.Path]::GetFullPath($$_.Path), $$target, [StringComparison]::OrdinalIgnoreCase) } catch { $$false } }) }; $$owned = @(GetOwnedAdb); if ($$owned.Count -eq 0) { exit 0 }; if (-not (Test-Path -LiteralPath $$target -PathType Leaf)) { exit 1 }; & $$target kill-server 2>&1 | Out-Null; $$deadline = [DateTime]::UtcNow.AddSeconds(5); do { if (@(GetOwnedAdb).Count -eq 0) { exit 0 }; Start-Sleep -Milliseconds 50 } while ([DateTime]::UtcNow -lt $$deadline); exit 1 }"'
+    Pop $0
+    Pop $1
+    System::Call 'Kernel32::SetEnvironmentVariableW(w "ADB_GUI_BUNDLED_ADB", p 0) i .r2'
+    StrCmp $0 "0" stop_bundled_adb_done
+
+    DetailPrint "Unable to stop the bundled ADB server before replacing its files."
+    ${If} ${Silent}
+    ${OrIf} $PassiveMode = 1
+      Abort
+    ${EndIf}
+
+    MessageBox MB_ICONEXCLAMATION|MB_RETRYCANCEL "ADB GUI's bundled ADB server is still using files in the install directory. Close ADB GUI and retry." IDRETRY stop_bundled_adb_retry
+    Abort
+
+  stop_bundled_adb_done:
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+  !insertmacro STOP_BUNDLED_ADB
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro STOP_BUNDLED_ADB
+!macroend

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,11 +1,128 @@
-import { RefreshCw } from "lucide-react";
-import { useState } from "react";
+import { Copy, Minus, RefreshCw, Square, X } from "lucide-react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { DevicePicker } from "@/components/layout/DevicePicker";
 import { WifiConnectButton } from "@/components/WifiConnect";
-import { getAdbInfo, listDevices } from "@/lib/tauri";
+import { getAdbInfo, isTauriRuntime, listDevices } from "@/lib/tauri";
 import { cn } from "@/lib/utils";
 import { useDeviceStore } from "@/store/device";
-import { useFeedbackStore } from "@/store/feedback";
+import { useFeedbackStore, type ToastKind } from "@/store/feedback";
+
+function isWindowsTauriRuntime(): boolean {
+  return isTauriRuntime() && /Windows/i.test(globalThis.navigator?.userAgent ?? "");
+}
+
+interface WindowControlButtonProps {
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+  danger?: boolean;
+}
+
+function WindowControlButton({
+  label,
+  onClick,
+  children,
+  danger = false,
+}: WindowControlButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className={cn(
+        "flex h-full w-11 items-center justify-center text-ink2 transition-colors hover:bg-hover hover:text-ink",
+        danger && "hover:bg-err hover:text-onink",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+interface WindowControlsProps {
+  showToast: (kind: ToastKind, message: string) => void;
+}
+
+function WindowControls({ showToast }: WindowControlsProps) {
+  const [maximized, setMaximized] = useState(false);
+  const appWindow = useMemo(() => getCurrentWindow(), []);
+
+  useEffect(() => {
+    let disposed = false;
+
+    function syncMaximizedState(): void {
+      void appWindow
+        .isMaximized()
+        .then((nextMaximized) => {
+          if (!disposed) {
+            setMaximized(nextMaximized);
+          }
+        })
+        .catch(() => {
+          // Window state is only available in the desktop runtime.
+        });
+    }
+
+    syncMaximizedState();
+    let unlisten: (() => void) | null = null;
+    void appWindow
+      .onResized(syncMaximizedState)
+      .then((nextUnlisten) => {
+        if (disposed) {
+          nextUnlisten();
+        } else {
+          unlisten = nextUnlisten;
+        }
+      })
+      .catch(() => {
+        // Window event registration is unavailable outside the desktop runtime.
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [appWindow]);
+
+  function runWindowAction(action: () => Promise<void>, label: string): void {
+    void action().catch((error: unknown) => {
+      showToast("error", `${label}失败: ${String(error)}`);
+    });
+  }
+
+  return (
+    <div
+      className="flex h-full shrink-0 items-stretch border-l border-rule"
+      data-tauri-drag-region="false"
+    >
+      <WindowControlButton
+        label="最小化窗口"
+        onClick={() => runWindowAction(() => appWindow.minimize(), "最小化窗口")}
+      >
+        <Minus className="h-4 w-4" aria-hidden="true" />
+      </WindowControlButton>
+      <WindowControlButton
+        label={maximized ? "还原窗口" : "最大化窗口"}
+        onClick={() => runWindowAction(() => appWindow.toggleMaximize(), "切换窗口大小")}
+      >
+        {maximized ? (
+          <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+        ) : (
+          <Square className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+      </WindowControlButton>
+      <WindowControlButton
+        label="关闭窗口"
+        onClick={() => runWindowAction(() => appWindow.close(), "关闭窗口")}
+        danger
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </WindowControlButton>
+    </div>
+  );
+}
 
 export function TopBar() {
   const adbInfo = useDeviceStore((state) => state.adbInfo);
@@ -13,6 +130,7 @@ export function TopBar() {
   const setDevices = useDeviceStore((state) => state.setDevices);
   const showToast = useFeedbackStore((state) => state.showToast);
   const [refreshing, setRefreshing] = useState(false);
+  const windowsRuntime = isWindowsTauriRuntime();
   const adbLabel = adbInfo ? `adb ${adbInfo.version} · ${adbInfo.source}` : "adb 未就绪";
 
   async function refreshDevices() {
@@ -32,7 +150,13 @@ export function TopBar() {
   }
 
   return (
-    <header className="flex h-[54px] shrink-0 items-center gap-2.5 border-b border-rule bg-surface px-[18px]">
+    <header
+      className={cn(
+        "flex h-[54px] shrink-0 items-center gap-2.5 border-b border-rule bg-surface px-[18px]",
+        windowsRuntime && "pr-0",
+      )}
+      data-tauri-drag-region={windowsRuntime ? "deep" : undefined}
+    >
       <div className="flex w-[clamp(190px,32vw,292px)] min-w-0 items-center">
         <DevicePicker />
       </div>
@@ -53,6 +177,7 @@ export function TopBar() {
           {adbLabel}
         </span>
       </div>
+      {windowsRuntime && <WindowControls showToast={showToast} />}
     </header>
   );
 }


### PR DESCRIPTION
## Summary

- stop only the app-owned bundled ADB server during normal exit, legacy reinstall, and uninstall
- preserve Android Studio and external SDK ADB processes by matching the executable path
- use the existing top toolbar as the Windows custom title bar, with themed window controls and improved spacing
- document the Windows bundled-ADB ownership and reinstall contract in Trellis specs

## Validation

- `cargo check`
- `cargo fmt --check`
- `cargo test` (65 passed)
- `cargo clippy --all-targets -- -D warnings`
- `pnpm test` (28 files, 277 tests passed)
- `pnpm build`
- NSIS compilation with `makensis`
- real silent reinstall: old bundled ADB exited and installed DLL hash matched the package resource
- external SDK ADB remained running through reinstall and app shutdown
- Windows title bar minimize, maximize, restore, and close smoke tests passed

## Notes

- Automated drag gestures did not reliably move the window, so drag remains a manual-smoke item. The configured `data-tauri-drag-region="deep"` path is supported by the pinned Tauri 2.11.3 runtime.
- The local full Tauri command produced the Windows NSIS bundle, then stopped at updater signing because the local machine does not have `TAURI_SIGNING_PRIVATE_KEY`; release CI owns that credential.